### PR TITLE
Fixed in ghost 2.9.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,9 @@ class GitHubStorage extends BaseStorage {
     }
 
     getFilepath(filename) {
-        return removeLeadingSlash(path.join(this.config.destination, filename));
+        // 181229 Fixed resize image path error from ghost 2.9.x.
+        const filePath = path.join(this.config.destination, filename).replace(/\\/g, '/')
+        return removeLeadingSlash(filePath);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const isUrl = require("is-url");
 const readFile = Promise.promisify(fs.readFile);
 const removeLeadingSlash = require("remove-leading-slash");
 const request = Promise.promisify(require("request"));
+const https = require("https");
 
 class GitHubStorage extends BaseStorage {
     constructor(config) {
@@ -42,8 +43,22 @@ class GitHubStorage extends BaseStorage {
             .catch(() => false);
     }
 
+    // 181229 Fixed an error that can not read favicon from ghost 2.9.x
     read(options) {
-        // Not needed because absolute URLS are already used to link to the images
+        options = options || {};
+        options.path = (options.path || '').replace(/\/$|\\$/, '');
+        var targetPath = this.storagePath ? path.join(this.storagePath, options.path) : options.path;
+
+        return new Promise(function (resolve, reject) {
+            https.get(targetPath, function (res) {
+                var data = [];
+                res.on('data', function (chunk) {
+                    data.push(chunk);
+                }).on('end', function () {
+                    resolve(Buffer.concat(data))
+                });
+            });
+        });
     }
 
     save(file, targetDir) {


### PR DESCRIPTION
Fixed in ghost 2.9.x

Fixed an error that can not read favicon from ghost 2.9.x
![image](https://user-images.githubusercontent.com/11923112/50536010-43f8fd00-0b93-11e9-8dab-3b472ac4de0d.png)

Fixed resize image path error from ghost 2.9.x.
![image](https://user-images.githubusercontent.com/11923112/50535978-fd0b0780-0b92-11e9-81e6-adf423b5215d.png)
