### PR TITLE
Fixed in ghost 2.9.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class GitHubStorage extends BaseStorage {
     }
 
     getFilepath(filename) {
-        const filePath = path.join(this.config.destination, filename).replace(/\\/g, '/')
+        const filePath = path.join(this.config.destination, filename).replace(/\\/g, '/');
         return removeLeadingSlash(filePath);
     }
 }

--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ class GitHubStorage extends BaseStorage {
     }
 
     getFilepath(filename) {
-        return removeLeadingSlash(path.join(this.config.destination, filename));
+        const filePath = path.join(this.config.destination, filename).replace(/\\/g, '/')
+        return removeLeadingSlash(filePath);
     }
 }
 


### PR DESCRIPTION
Fixed in ghost 2.9.x

Fixed an error that can not read favicon from ghost 2.9.x  
![image](https://user-images.githubusercontent.com/11923112/50536010-43f8fd00-0b93-11e9-8dab-3b472ac4de0d.png) 

Fixed resize image path error from ghost 2.9.x.  
![image](https://user-images.githubusercontent.com/11923112/50535978-fd0b0780-0b92-11e9-81e6-adf423b5215d.png) 

ps. Pull request retry sorry, my server ghost is exploded 💀💥 and I'm GitHub Newbie... 