### PR TITLE
Set empty base URL by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ class GitHubStorage extends BaseStorage {
         this.owner = process.env.GHOST_GITHUB_OWNER || owner
         this.repo = process.env.GHOST_GITHUB_REPO || repo
 
-        const baseUrl = utils.removeTrailingSlashes(process.env.GHOST_GITHUB_BASE_URL || config.baseUrl)
+        const baseUrl = utils.removeTrailingSlashes(process.env.GHOST_GITHUB_BASE_URL || config.baseUrl || '')
         this.baseUrl = isUrl(baseUrl)
             ? baseUrl
             : `${RAW_GITHUB_URL}/${this.owner}/${this.repo}/${this.branch}`


### PR DESCRIPTION
When I tried using this plugin, I didn't include the last config item since it was noted as optional. I then realised after debugging that the adapter would fail if the option wasn't included (even if it was empty).