### PR TITLE
Fix destination option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ class GitHubStorage extends BaseStorage {
                     content: data
                 })
             })
-            .then(res => this.getUrl(res.data.content.path))
+            .then(res => this.getUrl(res.data.content.name))
             .catch(Promise.reject)
     }
 


### PR DESCRIPTION
If the destination folder is set, it will be repeated on save. (e.g. if the destination folder is set to `example/`, the file will be saved to `example/file.ext` but will be saved by Ghost as `example/example/file.ext`.) This change fixes that by referencing the file name only.