### PR TITLE
Fixes saved URLs when destination is not equal to '/'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ class GitHubStorage extends BaseStorage {
                     content: data
                 })
             })
-            .then(res => this.getLiveUrl(res.data.content.path))
+            .then(res => this.getUrl(res.data.content.path))
             .catch(Promise.reject)
     }
 
@@ -88,13 +88,6 @@ class GitHubStorage extends BaseStorage {
     }
 
     getUrl(filepath) {
-        const url = new URL(this.baseUrl)
-        url.pathname = `${utils.removeTrailingSlashes(url.pathname)}/${this.getFilepath(filepath)}`
-
-        return url.toString()
-    }
-
-	getLiveUrl(filepath) {
         const url = new URL(this.baseUrl)
         url.pathname = `${utils.removeTrailingSlashes(url.pathname)}/${filepath}`
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ class GitHubStorage extends BaseStorage {
                     content: data
                 })
             })
-            .then(res => this.getUrl(res.data.content.path))
+            .then(res => this.getLiveUrl(res.data.content.path))
             .catch(Promise.reject)
     }
 
@@ -87,12 +87,20 @@ class GitHubStorage extends BaseStorage {
         }
     }
 
-    getUrl(filename) {
+    getUrl(filepath) {
         const url = new URL(this.baseUrl)
-        url.pathname = `${utils.removeTrailingSlashes(url.pathname)}/${this.getFilepath(filename)}`
+        url.pathname = `${utils.removeTrailingSlashes(url.pathname)}/${this.getFilepath(filepath)}`
 
         return url.toString()
     }
+
+	getLiveUrl(filepath) {
+        const url = new URL(this.baseUrl)
+        url.pathname = `${utils.removeTrailingSlashes(url.pathname)}/${filepath}`
+
+        return url.toString()
+    }
+
 
     getFilepath(filename) {
         return utils.removeLeadingSlashes(path.join(this.destination, filename))


### PR DESCRIPTION
Previously, when directory was set to anything other than `/`, say, directory = `example/`, GitHub's API returns the filename and path. Instead of duplicating the path, we need a function that returns the path and filename received from GitHub and concatenates it with the baseUrl to prevent the previous behaviour of saving a string like `https://raw.githubusercontent.com[…]example/example/file.jpg`.