### PR TITLE
Add useRelativeUrls option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ class GitHubStorage extends BaseStorage {
         this.destination = process.env.GHOST_GITHUB_DESTINATION || destination || '/'
         this.owner = process.env.GHOST_GITHUB_OWNER || owner
         this.repo = process.env.GHOST_GITHUB_REPO || repo
-        this.saveRelative = process.env.GHOST_GITHUB_SAVE_RELATIVE || config.saveRelative || "false"
+        this.useRelativeUrls = process.env.GHOST_GITHUB_USE_RELATIVE_URLS === 'true' || config.useRelativeUrls || false
 
         const baseUrl = utils.removeTrailingSlashes(process.env.GHOST_GITHUB_BASE_URL || config.baseUrl || '')
 
@@ -80,10 +80,10 @@ class GitHubStorage extends BaseStorage {
                 })
             })
             .then(res => {
-                if (this.saveRelative === "true") {
-                    return `/${res.data.content.path}`;
+                if (this.useRelativeUrls) {
+                    return `/${res.data.content.path}`
                 }
-                return this.getUrl(res.data.content.path));
+                return this.getUrl(res.data.content.path)
 			})
             .catch(Promise.reject)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ class GitHubStorage extends BaseStorage {
         this.owner = process.env.GHOST_GITHUB_OWNER || owner
         this.repo = process.env.GHOST_GITHUB_REPO || repo
 
+        this.saveRelative = process.env.GHOST_GITHUB_SAVE_RELATIVE || config.saveRelative || "false"
+
         const baseUrl = utils.removeTrailingSlashes(process.env.GHOST_GITHUB_BASE_URL || config.baseUrl)
         this.baseUrl = isUrl(baseUrl)
             ? baseUrl
@@ -77,7 +79,12 @@ class GitHubStorage extends BaseStorage {
                     content: data
                 })
             })
-            .then(res => this.getUrl(res.data.content.path))
+            .then(res => {
+                if (this.saveRelative === "true") {
+                    return `/${res.data.content.path}`;
+                }
+                return this.getUrl(res.data.content.path));
+			})
             .catch(Promise.reject)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ class GitHubStorage extends BaseStorage {
         this.useRelativeUrls = process.env.GHOST_GITHUB_USE_RELATIVE_URLS === 'true' || config.useRelativeUrls || false
 
         const baseUrl = utils.removeTrailingSlashes(process.env.GHOST_GITHUB_BASE_URL || config.baseUrl || '')
-
         this.baseUrl = isUrl(baseUrl)
             ? baseUrl
             : `${RAW_GITHUB_URL}/${this.owner}/${this.repo}/${this.branch}`


### PR DESCRIPTION
(Sorry for all the changes but I've had an opportunity to dive in to this adapter and found it very useful. I thought others might have similar issues and needs to the ones I have.) 
This PR adds an option (which I have not documented, pending #24) to save a relative URL to Ghost instead of a hard URL link to GitHub's file. This allows authors to pull from their own repo, especially if using Ghost's Content API to build a serverless site. 